### PR TITLE
Fixed style and weight support

### DIFF
--- a/src/woff2base64.js
+++ b/src/woff2base64.js
@@ -221,7 +221,7 @@ class Woff2Base64 {
    */
   getFontWeight = (filename, font) => {
     return font.hasOwnProperty('weight') &&
-    this.fontWeights.hasOwnProperty(font.weight) ? font.weight : this.getFontWeightFromFilename(filename);
+    this.fontWeights.includes(font.weight) ? font.weight : this.getFontWeightFromFilename(filename);
 
   };
 
@@ -235,7 +235,7 @@ class Woff2Base64 {
    */
   getFontStyle = (filename, font) => {
     return font.hasOwnProperty('style') &&
-    this.fontStyles.hasOwnProperty(font.style) ? font.style : this.getFontStyleFromFilename(filename);
+    this.fontStyles.includes(font.style) ? font.style : this.getFontStyleFromFilename(filename);
   };
 
   /**

--- a/test/test.js
+++ b/test/test.js
@@ -57,6 +57,18 @@ describe('woff2base64', function () {
       expect(weight).to.equal('900');
     });
 
+    it('parses the font-weight', function () {
+      const fo = new Woff2Base64Class({}, options);
+      let weight = fo.getFontWeight('Roboto-Bold.woff2', {weight: 'bold'});
+      expect(weight).to.equal('bold');
+
+      weight = fo.getFontWeight('Roboto-Bold.woff2', {weight: '900'});
+      expect(weight).to.equal('900');
+
+      weight = fo.getFontWeight('Roboto-Regular.woff2', {weight: ''});
+      expect(weight).to.equal('normal');
+    });
+
     it('gets the font-style from filename', function () {
       const fo = new Woff2Base64Class({}, options);
 
@@ -68,6 +80,15 @@ describe('woff2base64', function () {
 
       style = fo.getFontStyleFromFilename('Roboto-BlackItalic-900.woff2');
       expect(style).to.equal('italic');
+    });
+
+    it('parses the font-style', function () {
+      const fo = new Woff2Base64Class({}, options);
+      let style = fo.getFontStyle('Roboto-BlackItalic-900.woff2', {style: 'italic'});
+      expect(style).to.equal('italic');
+
+      style = fo.getFontStyle('Roboto-Bold.woff2', {style: ''});
+      expect(style).to.equal('normal');
     });
 
     it('converts strings to base64', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -62,7 +62,7 @@ describe('woff2base64', function () {
       let weight = fo.getFontWeight('Roboto-Bold.woff2', {weight: 'bold'});
       expect(weight).to.equal('bold');
 
-      weight = fo.getFontWeight('Roboto-Bold.woff2', {weight: '900'});
+      weight = fo.getFontWeight('Roboto-BlackItalic-900.woff2', {weight: '900'});
       expect(weight).to.equal('900');
 
       weight = fo.getFontWeight('Roboto-Regular.woff2', {weight: ''});


### PR DESCRIPTION
this.fontWeights.hasOwnProperty was throwing an exception and not working for cases where a weight/style were manually provided (e.g. weight: '900'). This changes it to use Array.includes() and provides the test to ensure it works.